### PR TITLE
Refactor UUID test

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,37 +1,36 @@
 package main
 
 import (
-	"log"
 	"testing"
 )
 
-func Test(t *testing.T) {
+func TestUUID(t *testing.T) {
 
 	loadMudID()
 
 	id := makeUUID()
 	if !id.hasUUID() {
-		log.Fatalln("Failed to generate valid UUID.")
+		t.Fatalf("Failed to generate valid UUID.")
 	}
 
 	idStr := id.toString()
 	if idStr == "" {
-		log.Fatalln("Failed to convert UUID to string.")
+		t.Fatalf("Failed to convert UUID to string.")
 	}
 
 	idStrToID := DecodeUUIDString(idStr)
 	if id != idStrToID {
-		log.Fatalln("UUID string to id failed.")
+		t.Fatalf("UUID string to id failed.")
 	}
 
 	var lastUUID uuidData = makeUUID()
-	for x := 0; x < 100000000; x++ {
+	for x := 0; x < 1000; x++ {
 		id := makeUUID()
 		if lastUUID.T == id.T {
-			log.Fatalf("Duplicate unixnano on interation %v."+NEWLINE, x)
+			t.Fatalf("Duplicate unixnano on interation %v."+NEWLINE, x)
 		}
 		if lastUUID.R == id.R {
-			log.Fatalf("Duplicate rand on interation %v: rand was: %v"+NEWLINE, x, lastUUID.R)
+			t.Fatalf("Duplicate rand on interation %v: rand was: %v"+NEWLINE, x, lastUUID.R)
 		}
 		lastUUID = id
 	}
@@ -39,22 +38,22 @@ func Test(t *testing.T) {
 	idA := makeUUID()
 	idB := idA
 	if !idA.sameUUID(idB) {
-		log.Fatalln("sameUUID() didn't detect a match.")
+		t.Fatalf("sameUUID() didn't detect a match.")
 	}
 	idC := makeUUID()
 	if idA.sameUUID(idC) &&
 		idA.M != idC.M &&
 		idA.R != idC.R &&
 		idA.T != idC.T {
-		log.Fatalln("sameUUID() returned match on non-match.")
+		t.Fatalf("sameUUID() returned match on non-match.")
 	}
 
 	var test uuidData
 	if test.hasUUID() {
-		log.Fatalln("hasUUID() false positive")
+		t.Fatalf("hasUUID() false positive")
 	}
 	test = makeUUID()
 	if !test.hasUUID() {
-		log.Fatalln("hasUUID() false negative")
+		t.Fatalf("hasUUID() false negative")
 	}
 }


### PR DESCRIPTION
## Summary
- shorten the UUID collision loop
- rename test function
- use t.Fatalf instead of log.Fatal

## Testing
- `go test ./...` *(fails: Test_smush_doesnt_combine_any_hardblank_when_not_SMHardBlank)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc1a19a8832ab605139a4019edc5