### PR TITLE
Fix panic log name typo

### DIFF
--- a/panic.go
+++ b/panic.go
@@ -11,7 +11,7 @@ import (
 
 /* Handles panics */
 const panicDumpName = "panic.dat"
-const pnaicLogName = "panic.log"
+const panicLogName = "panic.log"
 
 func reportPanic(desc *descData, format string, args ...interface{}) {
 	if r := recover(); r != nil {
@@ -30,7 +30,7 @@ func reportPanic(desc *descData, format string, args ...interface{}) {
 		desc.sendln("Sorry, something went wrong running the %v.", input)
 		buf := fmt.Sprintf("(GAME PANIC)"+NEWLINE+"BUILD:%v-%v-%v"+NEWLINE+"Label:%v File: %v Line: %v"+NEWLINE+"Error:%v"+NEWLINE+NEWLINE+"Stack Trace:"+NEWLINE+"%v"+NEWLINE, VERSION, VWHEN, CODENAME, input, filepath.Base(filename), line, r, string(debug.Stack()))
 
-		panicLogFile := fmt.Sprintf("%v/%v/%v-%v", DATA_DIR, PANIC_DIR, now, pnaicLogName)
+		panicLogFile := fmt.Sprintf("%v/%v/%v-%v", DATA_DIR, PANIC_DIR, now, panicLogName)
 		os.WriteFile(panicLogFile, []byte(buf), 0660)
 		critLog(buf)
 	}


### PR DESCRIPTION
## Summary
- fix constant name typo in `panic.go`

## Testing
- `go test ./...` *(fails: Test_smush_doesnt_combine_any_hardblank_when_not_SMHardBlank)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc11fef8832aa90d1a350eba2edc