### PR TITLE
Fix font directory guessing

### DIFF
--- a/figletlib/fonts_loader.go
+++ b/figletlib/fonts_loader.go
@@ -64,7 +64,7 @@ func FontNamesInDir(dir string) ([]string, error) {
 
 func GetFontByName(dirname, name string) (*Font, error) {
 	if dirname == "" {
-		dirname := GuessFontsDirectory()
+		dirname = GuessFontsDirectory()
 		if dirname == "" {
 			return nil, errors.New("Could not find fonts directory!")
 		}


### PR DESCRIPTION
## Summary
- ensure `GetFontByName` assigns guessed directory to outer variable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fdefe8f2c832a87b8c6777404bd99