### PR TITLE
Replace ioutil with os.ReadFile

### DIFF
--- a/figletlib/fonts.go
+++ b/figletlib/fonts.go
@@ -2,7 +2,7 @@ package figletlib
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -113,7 +113,7 @@ func (f *Font) Settings() Settings {
 }
 
 func ReadFont(filename string) (*Font, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- update figletlib to use `os.ReadFile` instead of `ioutil.ReadFile`

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684fdf2d99ec832ab9959737ca2622dc