### PR TITLE
Improve force command handling

### DIFF
--- a/descInterp.go
+++ b/descInterp.go
@@ -198,22 +198,27 @@ func (player *characterData) handleCommands(input string) {
 
 }
 
+func executeCommand(player *characterData, command *commandData, args string) {
+	if command.disabled {
+		player.send("That command is disabled.")
+		return
+	}
+
+	if command.checkCommandLevel(player) {
+		if command.forceArg != "" {
+			command.goDo(player, command.forceArg)
+		} else {
+			command.goDo(player, args)
+		}
+	}
+}
+
 func parseCommand(player *characterData, input string) {
 	cmdStr, args, _ := strings.Cut(input, " ")
 	cmdStr = strings.ToLower(cmdStr)
 	command := cmdMap[cmdStr]
 	if command != nil {
-		if command.disabled {
-			player.send("That command is disabled.")
-			return
-		}
-		if command.checkCommandLevel(player) {
-			if command.forceArg != "" {
-				command.goDo(player, command.forceArg)
-			} else {
-				command.goDo(player, args)
-			}
-		}
+		executeCommand(player, command, args)
 	} else {
 		if cmdChat(player, input) {
 			if !findCommandMatch(cmdList, player, cmdStr, args) {

--- a/wiz_cmd.go
+++ b/wiz_cmd.go
@@ -63,10 +63,16 @@ func cmdForce(player *characterData, input string) {
 	}
 }
 
-/* To do: remove dupe code */
+// goForce runs a command as if it were typed by another player. If the
+// command isn't found, the available command list is shown.
 func goForce(player *characterData, input string) {
 	cmdStr, args, _ := strings.Cut(input, " ")
 	cmdStr = strings.ToLower(cmdStr)
+
+	if cmdStr == "" {
+		player.listCommands("")
+		return
+	}
 
 	var command *commandData
 	for _, cmd := range cmdList {
@@ -75,18 +81,9 @@ func goForce(player *characterData, input string) {
 			break
 		}
 	}
+
 	if command != nil {
-		if command.disabled {
-			player.send("That command is disabled.")
-			return
-		}
-		if command.checkCommandLevel(player) {
-			if command.forceArg != "" {
-				command.goDo(player, command.forceArg)
-			} else {
-				command.goDo(player, args)
-			}
-		}
+		executeCommand(player, command, args)
 	} else {
 		if cmdChat(player, input) {
 			if !findCommandMatch(cmdList, player, cmdStr, args) {


### PR DESCRIPTION
## Summary
- refactor the force command implementation
- add an `executeCommand` helper to reduce duplicate dispatch logic

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684fe0902d00832aa836307b3150d3e2